### PR TITLE
Contacts and Groups: List and Access Shared posts.

### DIFF
--- a/dt-contacts/contacts-endpoints.php
+++ b/dt-contacts/contacts-endpoints.php
@@ -576,7 +576,7 @@ class Disciple_Tools_Contacts_Endpoints
         if (isset( $params['s'] )){
             $search = $params['s'];
         }
-        $contacts = Disciple_Tools_Contacts::get_viewable_contacts_compact( true, $search );
+        $contacts = Disciple_Tools_Contacts::get_viewable_contacts_compact( $search );
         return $contacts;
     }
 }

--- a/dt-contacts/contacts-endpoints.php
+++ b/dt-contacts/contacts-endpoints.php
@@ -273,11 +273,11 @@ class Disciple_Tools_Contacts_Endpoints
         }
     }
 
-    private function add_related_info_to_contacts( WP_Query $contacts ): array {
+    private function add_related_info_to_contacts( array $contacts ): array {
         p2p_type( 'contacts_to_locations' )->each_connected( $contacts, array(), 'locations' );
         p2p_type( 'contacts_to_groups' )->each_connected( $contacts, array(), 'groups' );
         $rv = array();
-        foreach ($contacts->posts as $contact) {
+        foreach ($contacts as $contact) {
             $meta_fields = get_post_custom( $contact->ID );
             $contact_array = $contact->to_array();
             $contact_array['permalink'] = get_post_permalink( $contact->ID );
@@ -403,7 +403,7 @@ class Disciple_Tools_Contacts_Endpoints
             if (is_wp_error( $contacts )) {
                 return $contacts;
             }
-            return $this->add_related_info_to_contacts( $contacts );
+            return $this->add_related_info_to_contacts( $contacts->posts );
         } else {
             return new WP_Error( "get_user_contacts", "Missing a valid user id", ['status' => 400] );
         }

--- a/dt-contacts/contacts.php
+++ b/dt-contacts/contacts.php
@@ -576,9 +576,15 @@ class Disciple_Tools_Contacts extends Disciple_Tools_Posts
             return $queried_contacts;
         }
         $contacts = $queried_contacts->posts;
+        $contact_ids = array_map(
+            function( $contact ){
+                return $contact->ID;
+            },
+            $contacts
+        );
         //add shared contacts to the list avoiding duplicates
         foreach ( $contacts_shared_with_user as $shared ){
-            if(!in_array( $shared, $contacts )){
+            if(!in_array( $shared->ID, $contact_ids )){
                 $contacts[] = $shared;
             }
         }

--- a/dt-contacts/contacts.php
+++ b/dt-contacts/contacts.php
@@ -13,7 +13,7 @@ if ( ! defined( 'ABSPATH' ) ) { exit; } // Exit if accessed directly.
  * Functions for creating, finding, updating or deleting contacts
  */
 
-class Disciple_Tools_Contacts
+class Disciple_Tools_Contacts extends Disciple_Tools_Posts
 {
     public static $contact_fields;
     public static $channel_list;
@@ -27,7 +27,7 @@ class Disciple_Tools_Contacts
                 self::$address_types = dt_address_metabox()->get_address_type_list( "contacts" );
             }
         );
-
+        parent::__construct();
     }
 
     /**
@@ -154,7 +154,7 @@ class Disciple_Tools_Contacts
      */
     public static function update_contact( int $contact_id, array $fields, bool $check_permissions = true ){
 
-        if ($check_permissions && ! self::can_update_contact( $contact_id )) {
+        if ($check_permissions && ! self::can_update( 'contacts', $contact_id )) {
             return new WP_Error( __FUNCTION__, __( "You do not have permission for this" ), ['status' => 403] );
         }
 
@@ -247,7 +247,7 @@ class Disciple_Tools_Contacts
 
 
     public static function add_contact_detail( int $contact_id, string $key, string $value, bool $check_permissions ){
-        if ($check_permissions && ! self::can_update_contact( $contact_id )) {
+        if ($check_permissions && ! self::can_update( 'contacts', $contact_id )) {
             return new WP_Error( __FUNCTION__, __( "You do not have permission for this" ), ['status' => 403] );
         }
         if (strpos( $key, "new-" ) === 0 ){
@@ -293,7 +293,7 @@ class Disciple_Tools_Contacts
 
 
     public static function update_contact_details( int $contact_id, string $key, array $values, bool $check_permissions ){
-        if ($check_permissions && ! self::can_update_contact( $contact_id )) {
+        if ($check_permissions && ! self::can_update( 'contacts', $contact_id )) {
             return new WP_Error( __FUNCTION__, __( "You do not have permission for this" ), ['status' => 403] );
         }
         if ( ( strpos( $key, "contact_" ) === 0 || strpos( $key, "address_" ) === 0 ) &&
@@ -311,7 +311,7 @@ class Disciple_Tools_Contacts
         return $contact_id;
     }
     public static function delete_contact_details( int $contact_id, string $key, string $value, bool $check_permissions ){
-        if ($check_permissions && ! self::can_update_contact( $contact_id )) {
+        if ($check_permissions && ! self::can_update( 'contacts', $contact_id )) {
             return new WP_Error( __FUNCTION__, __( "You do not have permission for this" ), ['status' => 403] );
         }
         if ( $key === "locations" ){
@@ -341,7 +341,7 @@ class Disciple_Tools_Contacts
      * @return WP_Post| WP_Error, On success: the contact, else: the error message
      */
     public static function get_contact( int $contact_id, bool $check_permissions = true ){
-        if ($check_permissions && ! self::can_view_contact( $contact_id )) {
+        if ($check_permissions && ! self::can_view( 'contacts',  $contact_id )) {
             return new WP_Error( __FUNCTION__, __( "No permissions to read contact" ), ['status' => 403] );
         }
 
@@ -531,7 +531,7 @@ class Disciple_Tools_Contacts
      * @return WP_Query | WP_Error
      */
     public static function get_user_contacts( int $user_id, bool $check_permissions = true, array $query_pagination_args = [] ) {
-        if ($check_permissions && ! self::can_access_contacts()) {
+        if ($check_permissions && ! self::can_access( 'contacts' )) {
             return new WP_Error( __FUNCTION__, __( "You do not have access to these contacts" ), ['status' => 403] );
         }
 
@@ -558,7 +558,7 @@ class Disciple_Tools_Contacts
      */
     public static function get_user_prioritized_contacts( int $user_id, string $priority, bool $check_permissions = true, array $query_pagination_args = [] ) {
         if ($check_permissions) {
-            if (! self::can_access_contacts() ) {
+            if (! self::can_access( 'contacts' ) ) {
                 return new WP_Error( __FUNCTION__, __( "You do not have access to these contacts" ), ['status' => 403] );
             }
         }
@@ -608,10 +608,10 @@ class Disciple_Tools_Contacts
      * @param  $query_pagination_args Pass in pagination and ordering parameters if wanted.
      * @access public
      * @since  0.1
-     * @return WP_Query | WP_Error
+     * @return array | WP_Error
      */
     public static function get_viewable_contacts( bool $check_permissions = true, array $query_pagination_args = [] ) {
-        if ($check_permissions && !self::can_access_contacts()) {
+        if ($check_permissions && !self::can_access( 'contacts' )) {
             return new WP_Error( __FUNCTION__, __( "You do not have access to these contacts" ), ['status' => 403] );
         }
         $current_user = wp_get_current_user();
@@ -620,30 +620,40 @@ class Disciple_Tools_Contacts
             'post_type' => 'contacts',
             'nopaging' => true,
         );
-        if (!self::can_view_all_contacts()){
+        $contacts = [];
+        if (!self::can_view_all( 'contacts' )){
             $query_args['meta_key'] = 'assigned_to';
             $query_args['meta_value'] = "user-". $current_user->ID;
+            $contacts = self::get_posts_shared_with_user( 'contacts', $current_user->ID );
         }
-        return self::query_with_pagination( $query_args, $query_pagination_args );
+        $queried_contacts = self::query_with_pagination( $query_args, $query_pagination_args );
+        if ( is_wp_error( $queried_contacts )){
+            return $queried_contacts;
+        }
+        return array_merge( $contacts, $queried_contacts->posts );
     }
 
 
     public static function get_viewable_contacts_compact( bool $check_permissions, string $searchString ){
-        if ($check_permissions && !self::can_access_contacts()) {
+        if ($check_permissions && !self::can_access( 'contacts' )) {
             return new WP_Error( __FUNCTION__, __( "You do not have access to these contacts" ), ['status' => 403] );
         }
         $current_user = wp_get_current_user();
+        $compact = [];
 
         $query_args = array(
             'post_type' => 'contacts',
             's' => $searchString
         );
-        if (!self::can_view_all_contacts()){
+        if (!self::can_view_all( 'contacts' )){
             $query_args['meta_key'] = 'assigned_to';
             $query_args['meta_value'] = "user-". $current_user->ID;
+            $shared_contacts = self::get_posts_shared_with_user( 'contacts', $current_user->ID );
+            foreach( $shared_contacts as $post ){
+                $list[] = ["ID" => $post->ID, "name" => $post->post_title];
+            }
         }
         $contacts = new WP_Query( $query_args );
-        $compact = [];
         foreach( $contacts->posts as $contact ){
             $compact[] = ["ID" => $contact->ID, "name" => $contact->post_title];
         }
@@ -664,7 +674,7 @@ class Disciple_Tools_Contacts
         if ($check_permissions) {
             $current_user = wp_get_current_user();
             // TODO: the current permissions required don't make sense
-            if (! self::can_access_contacts()
+            if (! self::can_access( 'contacts' )
                 || ($user_id != $current_user->ID && ! current_user_can( 'edit_team_contacts' )))
             {
                 return new WP_Error( __FUNCTION__, __( "You do not have permission" ), ['status' => 404] );
@@ -795,7 +805,7 @@ class Disciple_Tools_Contacts
     }
 
     public static function add_comment( int $contact_id, string $comment, bool $check_permissions = true ){
-        if ($check_permissions && ! self::can_update_contact( $contact_id )) {
+        if ($check_permissions && ! self::can_update( 'contacts', $contact_id )) {
             return new WP_Error( __FUNCTION__, __( "You do not have permission for this" ), ['status' => 403] );
         }
         $user = wp_get_current_user();
@@ -814,7 +824,7 @@ class Disciple_Tools_Contacts
     }
 
     public static function get_comments ( int $contact_id, bool $check_permissions = true ){
-        if ($check_permissions && ! self::can_view_contact( $contact_id )) {
+        if ($check_permissions && ! self::can_view( 'contacts', $contact_id )) {
             return new WP_Error( __FUNCTION__, __( "No permissions to read contact" ), ['status' => 403] );
         }
         $comments = get_comments( ['post_id'=>$contact_id] );
@@ -822,54 +832,10 @@ class Disciple_Tools_Contacts
     }
 
 
-    public static function can_access_contacts(){
-        return current_user_can( "access_contacts" );
-    }
-
-    public static function can_view_contact( int $contact_id ){
-        if ( current_user_can( 'view_any_contact' )){
-            return true;
-        } else {
-            $user = wp_get_current_user();
-            $assigned_to = get_post_meta( $contact_id, "assigned_to", true );
-            if ( $assigned_to === "user-".$user->ID ){
-                return true;
-            }
-//          @TODO check if the user is following this contact
-        }
-        return false;
-    }
-
-    public static function can_update_contact( int $contact_id ){
-        if ( current_user_can( 'update_any_contact' )){
-            return true;
-        } else {
-            $user = wp_get_current_user();
-            $assigned_to = get_post_meta( $contact_id, "assigned_to", true );
-            if ( $assigned_to === "user-".$user->ID ){
-                return true;
-            }
-//          @TODO check if the user is following this contact and can update
-
-        }
-        return false;
-    }
-
-    public static function can_delete_contact( int $contact_id ){
-        return current_user_can( 'delete_any_contact' );
-    }
-
-    public static function can_create_contact(){
-        return current_user_can( 'create_contacts' );
-    }
-
-    public static function can_view_all_contacts(){
-        return current_user_can( 'view_any_contact' );
-    }
 
 
     public static function accept_contact( int $contact_id, bool $accepted, bool $check_permissions ){
-        if (!self::can_update_contact( $contact_id )){
+        if (!self::can_update( 'contacts', $contact_id )){
             return new WP_Error( __FUNCTION__, __( "You do not have permission for this" ), ['status' => 403] );
         }
 
@@ -894,7 +860,7 @@ class Disciple_Tools_Contacts
     public static function get_shared_with( int $post_id ) {
         global $wpdb;
 
-        if (!self::can_update_contact( $post_id )){
+        if (!self::can_update( 'contacts', $post_id )){
             return new WP_Error( __FUNCTION__, __( "You do not have permission for this" ), ['status' => 403] );
         }
 
@@ -920,7 +886,7 @@ class Disciple_Tools_Contacts
     public static function remove_shared( int $post_id, int $user_id ) {
         global $wpdb;
 
-        if (!self::can_update_contact( $post_id )){
+        if (!self::can_update( 'contacts', $post_id )){
             return new WP_Error( __FUNCTION__, __( "You do not have permission for this" ), ['status' => 403] );
         }
 
@@ -947,7 +913,7 @@ class Disciple_Tools_Contacts
     public static function add_shared( int $post_id, int $user_id, $meta = null ) {
         global $wpdb;
 
-        if (!self::can_update_contact( $post_id )){
+        if (!self::can_update( 'contacts', $post_id )){
             return new WP_Error( __FUNCTION__, __( "You do not have permission for this" ), ['status' => 403] );
         }
 

--- a/dt-core/admin/class-roles.php
+++ b/dt-core/admin/class-roles.php
@@ -43,10 +43,10 @@ $template = [
     /* Add custom caps for contacts */
     'create_contacts' => true,  //create a new contact
     'update_shared_contacts' => true,
-    'view_any_contact' => true,    //view any contacts
-    'assign_any_contact' => true,  //assign contacts to others
-    'update_any_contact' => true,  //update any contacts
-    'delete_any_contact' => true,  //delete any contacts
+    'view_any_contacts' => true,    //view any contacts
+    'assign_any_contacts' => true,  //assign contacts to others
+    'update_any_contacts' => true,  //update any contacts
+    'delete_any_contacts' => true,  //delete any contacts
 
     /* Add custom caps for groups */
     'access_groups' => true,
@@ -322,10 +322,10 @@ class Disciple_Tools_Roles {
                 'access_contacts' => true,
                 'create_contacts' => true,  //create a new contact
                 'update_shared_contacts' => true,
-                'view_any_contact' => true,    //view any contacts
-                'assign_any_contact' => true,  //assign contacts to others
-                'update_any_contact' => true,  //update any contacts
-                'delete_any_contact' => true,  //delete any contacts
+                'view_any_contacts' => true,    //view any contacts
+                'assign_any_contacts' => true,  //assign contacts to others
+                'update_any_contacts' => true,  //update any contacts
+                'delete_any_contacts' => true,  //delete any contacts
 
                 /* Add custom caps for groups */
                 'access_groups' => true,
@@ -656,10 +656,10 @@ class Disciple_Tools_Roles {
             $role->add_cap( 'create_contacts' );
             $role->add_cap( 'update_contacts' );
             $role->add_cap( 'update_shared_contacts' );
-            $role->add_cap( 'view_any_contact' );
-            $role->add_cap( 'assign_any_contact' );
-            $role->add_cap( 'update_any_contact' );
-            $role->add_cap( 'delete_any_contact' );
+            $role->add_cap( 'view_any_contacts' );
+            $role->add_cap( 'assign_any_contacts' );
+            $role->add_cap( 'update_any_contacts' );
+            $role->add_cap( 'delete_any_contacts' );
             /* Add Groups permissions */
             $role->add_cap( 'access_groups' );
             $role->add_cap( 'create_groups' );

--- a/dt-core/posts.php
+++ b/dt-core/posts.php
@@ -75,7 +75,7 @@ class Disciple_Tools_Posts {
                     ARRAY_A
                 );
                 foreach ($shares as $share) {
-                    if ( $share->ID === $user->ID ) {
+                    if ( (int) $share['user_id'] === $user->ID ) {
                         return true;
                     }
                 }
@@ -105,7 +105,7 @@ class Disciple_Tools_Posts {
                     ARRAY_A
                 );
                 foreach ($shares as $share) {
-                    if ( $share->ID === $user->ID ) {
+                    if ( (int) $share['user_id'] === $user->ID ) {
                         return true;
                     }
                 }
@@ -118,12 +118,15 @@ class Disciple_Tools_Posts {
     public static function get_posts_shared_with_user( string $post_type, int $user_id ){
         global $wpdb;
         $shares = $wpdb->get_results(
-            "SELECT * FROM $wpdb->dt_share WHERE user_id = '$user_id'",
+            "SELECT * FROM $wpdb->dt_share as shares 
+            INNER JOIN $wpdb->posts as posts 
+            WHERE user_id = '$user_id' 
+            AND shares.post_id = posts.ID 
+            AND posts.post_type = '" . $post_type . "'",
             ARRAY_A
         );
         $list = [];
         foreach($shares as $share){
-//          get the shares with a specific post_typo @todo add to shares table
             $post = get_post( $share[ "user_id" ] );
             if (isset( $post->post_type ) && $post->post_type === $post_type){
                 $list[] = $post;

--- a/dt-groups/groups-endpoints.php
+++ b/dt-groups/groups-endpoints.php
@@ -103,11 +103,11 @@ class Disciple_Tools_Groups_Endpoints {
     }
 
 
-    private function add_related_info_to_groups( WP_Query $groups ): array {
+    private function add_related_info_to_groups( array $groups ): array {
         p2p_type( 'groups_to_locations' )->each_connected( $groups, array(), 'locations' );
         p2p_type( 'contacts_to_groups' )->each_connected( $groups, array(), 'contacts' );
         $rv = array();
-        foreach ($groups->posts as $group) {
+        foreach ($groups as $group) {
             $meta_fields = get_post_custom( $group->ID );
             $group_array = $group->to_array();
             unset( $group_array['contacts'] );

--- a/dt-groups/groups-endpoints.php
+++ b/dt-groups/groups-endpoints.php
@@ -95,7 +95,7 @@ class Disciple_Tools_Groups_Endpoints {
     }
 
     public function get_viewable_groups( WP_REST_Request $request ) {
-        $groups = Disciple_Tools_Groups::get_viewable_groups( true );
+        $groups = Disciple_Tools_Groups::get_viewable_groups();
         if (is_wp_error( $groups )) {
             return $groups;
         }

--- a/dt-groups/groups.php
+++ b/dt-groups/groups.php
@@ -38,35 +38,8 @@ class Disciple_Tools_Groups extends Disciple_Tools_Posts {
     }
 
 
-    public static function get_viewable_groups( bool $check_permissions = true ) {
-        if ($check_permissions && !self::can_access( 'groups' )) {
-            return new WP_Error( __FUNCTION__, __( "You do not have access to these groups" ), ['status' => 403] );
-        }
-        $current_user = wp_get_current_user();
-
-        $query_args = array(
-            'post_type' => 'groups',
-            'nopaging' => true,
-        );
-        $groups_shared_with_user = [];
-        if (!self::can_view_all( 'groups' )){
-            $groups_shared_with_user = self::get_posts_shared_with_user( 'groups', $current_user->ID );
-
-            $query_args['meta_key'] = 'assigned_to';
-            $query_args['meta_value'] = "user-". $current_user->ID;
-        }
-        $queried_groups = new WP_Query( $query_args );
-        if ( is_wp_error( $queried_groups )){
-            return $queried_groups;
-        }
-        $groups = $queried_groups->posts;
-        //add shared groups to the list avoiding duplicates
-        foreach ( $groups_shared_with_user as $shared ){
-            if(!in_array( $shared, $groups )){
-                $groups[] = $shared;
-            }
-        }
-        return $groups;
+    public static function get_viewable_groups() {
+        return self::get_viewable( 'groups' );
     }
 
     public static function get_group( int $group_id, bool $check_permissions = true ){

--- a/dt-groups/groups.php
+++ b/dt-groups/groups.php
@@ -65,15 +65,20 @@ class Disciple_Tools_Groups extends Disciple_Tools_Posts {
             return new WP_Error( __FUNCTION__, __( "You do not have access to these groups" ), ['status' => 403] );
         }
         $current_user = wp_get_current_user();
-
+        $groups = [];
         $query_args = array(
             'post_type' => 'groups',
         );
         if (! self::can_view_all( 'groups' )) {
-            // TODO filter just by own groups
-            return new WP_Error( __FUNCTION__, __( "Unimplemented" ) );
+            $query_args['meta_key'] = 'assigned_to';
+            $query_args['meta_value'] = "user-". $current_user->ID;
+            $groups = self::get_posts_shared_with_user( 'groups', $current_user->ID );
         }
-        return new WP_Query( $query_args );
+        $queried_groups = new WP_Query( $query_args );
+        if ( is_wp_error( $queried_groups )){
+            return $queried_groups;
+        }
+        return array_merge( $groups, $queried_groups->posts );
     }
 
     public static function get_group( int $group_id, bool $check_permissions = true ){


### PR DESCRIPTION
Shared contacts now appear in the contacts and groups list. Also you have access to the contacts and groups that are shared with you.
I moved the permission checking to the code in the posts.php. I had to change the permissions slightly for this to work. So this requires a `Roles Refresh` in the DEMO plugin.
@burntsun I changed some of your code to get the list of contacts and groups. Can you check that it still work for you?
When this is merged, https://github.com/ChasmSolutions/disciple-tools-theme/pull/46 can be merged too
